### PR TITLE
Make it explicit the `unzip` command is required for archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 npm install verrazzano --save
 ```
 
+**Notice**: the `unzip` command must be available on the system in order to handle zipped inputs.
+
 ## Supported Formats
 
 ### Parsing


### PR DESCRIPTION
I had to run `apt update && apt install -y unzip` to make it work in a container… without `unzip` 😅 